### PR TITLE
Fix typo in name

### DIFF
--- a/password validator/1.2/function.json
+++ b/password validator/1.2/function.json
@@ -1,6 +1,6 @@
 {
   "description": "This password validator function allows you to validate passwords based on various criteria such as length, the presence of special characters, uppercase and lowercase letters, and a custom regular expression. It returns a Boolean",
-  "label": "Password Validater",
+  "label": "Password Validator",
   "category": "Misc",
   "icon": {
     "name": "ConditionIcon",


### PR DESCRIPTION
Fixed a typo in the title of the action step;
"... Validater" --> "... Validator"