### PR TITLE
fix: fail on empty password

### DIFF
--- a/password validator/1.2/index.js
+++ b/password validator/1.2/index.js
@@ -1,5 +1,6 @@
 const password = async ({ Password, digits, minLength, maxLength, specialCharacter, upperCase, lowerCase, SpecifiedChar, customRegex }) => {
     const checkPassword = (password) => {
+        if(!password) throw new Error("Unable to validate password! No password given");
         isValid = true
         if (minLength || maxLength) {
             const maxlengthvalid = password.length <= maxLength ? true : false


### PR DESCRIPTION
Previously failed cryptically when no password was provided. We can prevent this from happening by providing an empty string as a default value